### PR TITLE
Fix cmake bug on linux

### DIFF
--- a/src/SiftGPU/CMakeLists.txt
+++ b/src/SiftGPU/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)
-find_package(Glew)
+find_package(GLEW)
 
 SET(SIFTGPU_ENABLE_SERVER FALSE)
 SET(SIFTGPU_ENABLE_OPENCL FALSE)


### PR DESCRIPTION
CMake is case sensitive (on linux) so instead of 'Glew' one should use 'GLEW' in find_package function.