### PR TITLE
Fixing CMakeLists.txt for SiftGPU to use GLEW, not Glew.

### DIFF
--- a/src/SiftGPU/CMakeLists.txt
+++ b/src/SiftGPU/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)
-find_package(Glew)
+find_package(GLEW)
 
 SET(SIFTGPU_ENABLE_SERVER FALSE)
 SET(SIFTGPU_ENABLE_OPENCL FALSE)


### PR DESCRIPTION
Tested with libglew 1.10, on Ubuntu 14.04.